### PR TITLE
In-place upgrade av postgres fra 12 til 14.

### DIFF
--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -13,7 +13,7 @@
   "database": {
     "name": "k9-brukerdialog-cache-db",
     "envVarPrefix": "DB",
-    "type": "POSTGRES_12",
+    "type": "POSTGRES_14",
     "tier": "db-custom-2-7680",
     "diskSize": "100",
     "diskType": "SSD",


### PR DESCRIPTION
Instansen i dev-gcp var allerede på 14.

Dette påvirker mellomlagrede søknader i brukerdialog. Det kan i værste fall føre til at bruker må fylle ut alt på nytt.
Bør merges inn når det er minst pågang.