### PR TITLE
Update Spring Boot plugin version to 4.0.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     kotlin("jvm") version "2.3.20"
     kotlin("plugin.spring") version "2.3.20"
     kotlin("plugin.jpa") version "2.3.20"
-    id("org.springframework.boot") version "4.0.5"
+    id("org.springframework.boot") version "4.0.6"
     id("io.spring.dependency-management") version "1.1.7"
     id("org.sonarqube") version "7.2.3.7755"
     jacoco


### PR DESCRIPTION
### Bakgrunn
Kritisk sårbarhet i spring boot 4.0.5 er oppdaget

### Løsning
Bumper til 4.0.6